### PR TITLE
added an event "rowCreatedEvent", triggered after the row is created and...

### DIFF
--- a/script/simplePagingGrid-0.6.0.0.js
+++ b/script/simplePagingGrid-0.6.0.0.js
@@ -674,6 +674,9 @@
                             tr.append(td);
                         });
                         that._tbody.append(tr);
+                        if (that._settings.rowCreatedEvent !== null) {
+                            that._settings.rowCreatedEvent(tr, rowData);
+                        }
                     }
                 });
 
@@ -803,6 +806,7 @@
             showGotoPage: true,
             numberOfPageLinks: 10,
             pageRenderedEvent: null,
+            rowCreatedEvent: null,
             ajaxError: null,
             showHeader: true,
             pageNumber: 0,


### PR DESCRIPTION
I want to add some "data-" attributes to "tr" elements and tried the rowTemplates option, but the "{{ blablabla }}" syntax in rowTemplates isn't parsed, it outputs an empty string. I'm not good at handlebars, so I added an event triggered after the tr is created and appended to tbody. I think this event is quite convenient for people who want to customize the created row further.

The function has 2 parameters: the created tr and the rowData.
