### PR TITLE
Fix to pass row data into row templates.

### DIFF
--- a/script/simplePagingGrid-0.6.0.0.js
+++ b/script/simplePagingGrid-0.6.0.0.js
@@ -652,7 +652,7 @@
 
                 $.each(localPageData, function(rowIndex, rowData) {
                     if (rowIndex < that._settings.pageSize) {
-                        var tr = $(that._settings.rowTemplates[rowTemplateIndex](rowTemplateIndex));
+                        var tr = $(that._settings.rowTemplates[rowTemplateIndex](rowData));
                         rowTemplateIndex++;
                         if (rowTemplateIndex >= that._settings.rowTemplates.length) {
                             rowTemplateIndex = 0;


### PR DESCRIPTION
I was trying to use Handlebars in row templates but the row data wasn't being passed in; this change fixes it.
